### PR TITLE
Retry without AVPro if AVPro prefetch fails

### DIFF
--- a/VRCVideoCacher/API/APIController.cs
+++ b/VRCVideoCacher/API/APIController.cs
@@ -9,6 +9,9 @@ namespace VRCVideoCacher.API;
 
 public class ApiController : WebApiController
 {
+    // @TODO: Make this configurable via proposed API.
+    const int YoutubePrefetchMaxRetries = 7;
+
     private static readonly Serilog.ILogger Log = Program.Logger.ForContext<ApiController>();
     private static readonly HttpClient HttpClient = new()
     {
@@ -155,14 +158,14 @@ public class ApiController : WebApiController
             videoInfo.VideoUrl.StartsWith("https://manifest.googlevideo.com") ||
             videoInfo.VideoUrl.Contains("googlevideo.com"))
         {
-            var isPrefetchSuccessful = await VideoTools.Prefetch(response);
+            var isPrefetchSuccessful = await VideoTools.Prefetch(response, YoutubePrefetchMaxRetries);
 
             if(!isPrefetchSuccessful && avPro)
             {
                 Log.Warning("Prefetch failed with AVPro, retrying without AVPro.");
                 avPro = false;
                 (response, success) = await VideoId.GetUrl(videoInfo, avPro);
-                await VideoTools.Prefetch(response);
+                await VideoTools.Prefetch(response, YoutubePrefetchMaxRetries);
             }
 
             if (ConfigManager.Config.ytdlDelay > 0)

--- a/VRCVideoCacher/YTDL/VideoTools.cs
+++ b/VRCVideoCacher/YTDL/VideoTools.cs
@@ -5,7 +5,7 @@ public class VideoTools
     private static readonly Serilog.ILogger Log = Program.Logger.ForContext<VideoTools>();
     private static readonly HttpClient HttpClient = new();
 
-    public static async Task<bool> Prefetch(string videoUrl)
+    public static async Task<bool> Prefetch(string videoUrl, int maxRetryCount = 7)
     {
         // If the URL is invalid, skip prefetching
         if (string.IsNullOrWhiteSpace(videoUrl) || !Uri.IsWellFormedUriString(videoUrl, UriKind.RelativeOrAbsolute))
@@ -36,9 +36,8 @@ public class VideoTools
         
         // If we have an M3U8 URL, perform HEAD requests to validate accessibility
         var statusCode = 0;
-        const int requestLimit = 7;
         const int wait = 1500;
-        for (var i = 0; i < requestLimit; i++)
+        for (var i = 0; i < maxRetryCount; i++)
         {
             using var m3u8Request = new HttpRequestMessage(HttpMethod.Head, firstM3U8Url);
             using var m3u8Response = await HttpClient.SendAsync(m3u8Request);
@@ -48,7 +47,7 @@ public class VideoTools
             {
                 Log.Warning(
                     "Prefetching M3U8 stream returned status code {status}, retrying... ({attempt}/{limit})",
-                    statusCode, i + 1, requestLimit);
+                    statusCode, i + 1, maxRetryCount);
                 await Task.Delay(wait);
             }
             else
@@ -62,7 +61,7 @@ public class VideoTools
         {
             Log.Error(
                 "Prefetching M3U8 stream failed after {limit} attempts, status code {status}. Video may not play.",
-                requestLimit, statusCode);
+                maxRetryCount, statusCode);
             return false;
         }
         else


### PR DESCRIPTION
Retry without AVPro if AVPro prefetch fails. Helps alleviate https://github.com/EllyVR/VRCVideoCacher/issues/59