### PR TITLE
Fix app not closing correctly on linux

### DIFF
--- a/VRCVideoCacher/App.axaml.cs
+++ b/VRCVideoCacher/App.axaml.cs
@@ -211,6 +211,18 @@ public partial class App : Application
                     _desktop?.Shutdown();
                 });
             });
+            
+            //Pressing X on window does not remove the tray nor stop the console process
+            MainWindow!.Closing += (_, _) =>
+            {
+                if (ConfigManager.Config.CloseToTray || _isExiting)
+                    return;
+                
+                _isExiting = true;
+                _trayIcon?.Dispose();
+                _trayIcon = null;
+                _desktop?.Shutdown();
+            };
         }
 
         _showItem = new NativeMenuItem(Loc.Tr("TrayShow"));


### PR DESCRIPTION
- Tray Icon did not disappear when closing the GUi with `Close to Tray `disabled on linux
- Console process did not terminate when closing the GUI with `Close to Tray `disabled on linux
-> Manually stopping the app in Steam/console was required (tray icon did disappear as well in those cases)