### PR TITLE
Resolve theater mode issues.

### DIFF
--- a/VRCVideoCacher/ConfigManager.cs
+++ b/VRCVideoCacher/ConfigManager.cs
@@ -160,6 +160,7 @@ public class ConfigModel
     public bool AutoUpdateVrcVideoCacher = true;
     public bool CloseToTray = true;
     public bool StartMinimized = false;
+    public bool StartWithSteamVr = true;
     public bool CookieSetupCompleted = false;
     public bool RedirectVRDancing = false;
     

--- a/VRCVideoCacher/Languages/en.loc.json
+++ b/VRCVideoCacher/Languages/en.loc.json
@@ -60,6 +60,7 @@
   "AutoUpdateVRCVideoCacher": "Auto-update VRCVideoCacher",
   "CloseToTray": "Close to Tray",
   "StartMinimized": "Start Minimized",
+  "StartWithSteamVr": "Start with SteamVR",
   "BlockedUrls": "Blocked URLs",
   "BlockedUrlRedirect": "Blocked URL Redirect",
   "SettingsSaved": "Settings saved!",

--- a/VRCVideoCacher/Languages/hu.loc.json
+++ b/VRCVideoCacher/Languages/hu.loc.json
@@ -61,6 +61,7 @@
   "AutoUpdateVRCVideoCacher": "VRCVideoCacher Automatikus Frissítés",
   "CloseToTray": "Tálcára Csukás",
   "StartMinimized": "Indítás Minimalizálva",
+  "StartWithSteamVr": "Indítsd el az alkalmazást a SteamVR segítségével",
   "BlockedUrls": "Letiltott Linkek",
   "BlockedUrlRedirect": "Blokkolt Link Átirányítás",
   "SettingsSaved": "Beállítások Mentve!",

--- a/VRCVideoCacher/Languages/ja.loc.json
+++ b/VRCVideoCacher/Languages/ja.loc.json
@@ -60,6 +60,7 @@
   "AutoUpdateVRCVideoCacher": "VRCVideoCacher を自動更新する",
   "CloseToTray": "タスクトレイに収納する",
   "StartMinimized": "最小化して起動する",
+  "StartWithSteamVr": "SteamVRでアプリを起動する",
   "BlockedUrls": "ブロックする URL",
   "BlockedUrlRedirect": "ブロックした URL のリダイレクト",
   "SettingsSaved": "設定を保存しました！",

--- a/VRCVideoCacher/Languages/ko.loc.json
+++ b/VRCVideoCacher/Languages/ko.loc.json
@@ -60,6 +60,7 @@
   "AutoUpdateVRCVideoCacher": "VRCVideoCacher 자동 업데이트",
   "CloseToTray": "닫을 때 트레이로 최소화",
   "StartMinimized": "최소화된 상태로 시작",
+  "StartWithSteamVr": "SteamVR로 앱 실행",
   "BlockedUrls": "차단된 URL",
   "BlockedUrlRedirect": "차단된 URL 리디렉션",
   "SettingsSaved": "설정이 저장되었습니다!",

--- a/VRCVideoCacher/Languages/ru.loc.json
+++ b/VRCVideoCacher/Languages/ru.loc.json
@@ -60,6 +60,7 @@
   "AutoUpdateVRCVideoCacher": "Автообновления VRCVideoCacher",
   "CloseToTray": "Закрыть в Трей",
   "StartMinimized": "Запускать Свёрнутым",
+  "StartWithSteamVr": "Запустить приложение с помощью SteamVR",
   "BlockedUrls": "Заблокированный URL",
   "BlockedUrlRedirect": "Перенаправление Заблокированного URL",
   "SettingsSaved": "Настройки Сохранены!",

--- a/VRCVideoCacher/Languages/zh.loc.json
+++ b/VRCVideoCacher/Languages/zh.loc.json
@@ -60,6 +60,7 @@
   "AutoUpdateVRCVideoCacher": "自动更新 VRCVideoCacher",
   "CloseToTray": "关闭到系统托盘",
   "StartMinimized": "启动时最小化",
+  "StartWithSteamVr": "通过 SteamVR 启动应用",
   "BlockedUrls": "屏蔽的 URL",
   "BlockedUrlRedirect": "屏蔽 URL 重定向地址",
   "SettingsSaved": "设置已保存！",

--- a/VRCVideoCacher/Program.cs
+++ b/VRCVideoCacher/Program.cs
@@ -103,7 +103,7 @@ internal sealed class Program
                         try
                         {
                             process.Kill();
-                            Logger.Information("Killed existing instance with PID {Pid} due to --force-new-instance argument.", process.Id);
+                            Logger.Information("Killed existing instance with PID {Pid} due to kill existing instance argument.", process.Id);
                         }
                         catch (Exception ex)
                         {

--- a/VRCVideoCacher/Program.cs
+++ b/VRCVideoCacher/Program.cs
@@ -94,8 +94,29 @@ internal sealed class Program
         var processes = Process.GetProcessesByName("VRCVideoCacher");
         if (processes.Length > 1)
         {
-            Console.WriteLine("Application is already running, Exiting...");
-            Environment.Exit(0);
+            if (LaunchArgs.KillExistingInstance)
+            {
+                foreach (var process in processes)
+                {
+                    if (process.Id != Environment.ProcessId)
+                    {
+                        try
+                        {
+                            process.Kill();
+                            Logger.Information("Killed existing instance with PID {Pid} due to --force-new-instance argument.", process.Id);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Warning(ex, "Failed to kill existing instance with PID {Pid}. It may still be running.", process.Id);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                Console.WriteLine("Application is already running, Exiting...");
+                Environment.Exit(0);
+            }
         }
         foreach (var process in processes)
             process.Dispose();

--- a/VRCVideoCacher/Program.cs
+++ b/VRCVideoCacher/Program.cs
@@ -173,7 +173,7 @@ internal sealed class Program
             }
         });
         
-        OpenVRService.Start(DataPath);
+        OpenVRService.Start(CurrentProcessPath);
 
         // Start the UI
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);

--- a/VRCVideoCacher/Services/OpenVRService.cs
+++ b/VRCVideoCacher/Services/OpenVRService.cs
@@ -33,18 +33,27 @@ public class OpenVRService
                 switch (initError)
                 {
                     case EVRInitError.None:
-                    {
                         var manifestPath = Path.Combine(dataPath, "manifest.vrmanifest");
                         await using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("VRCVideoCacher.manifest.vrmanifest")!)
                         await using (var file = File.Create(manifestPath))
                             await stream.CopyToAsync(file);
                         var manifestError = OpenVR.Applications.AddApplicationManifest(manifestPath, false);
                         if (manifestError != EVRApplicationError.None)
-                            Logger.Warning("Failed to register manifest: {Error}", manifestError);
+                        {
+                            Logger.Warning("Failed to register startup manifest: {Error}", manifestError);
+                        }
                         else
-                            Logger.Information("Registered as background app");
+                        {
+                            if (OpenVR.Applications.IsApplicationInstalled("com.github.ellyvr.vrcvideocacher"))
+                            {
+                                Logger.Information("Startup manifest registered successfully");
+                            }
+                            else
+                            {
+                                Logger.Warning("Failed to register startup manifest");
+                            }
+                        }
                         break;
-                    }
                     // Only retry if vrserver just isn't running yet
                     case EVRInitError.Init_HmdNotFound or EVRInitError.Init_HmdNotFoundPresenceFailed or EVRInitError.Init_NoServerForBackgroundApp:
                         await Task.Delay(TimeSpan.FromSeconds(5));

--- a/VRCVideoCacher/Services/OpenVRService.cs
+++ b/VRCVideoCacher/Services/OpenVRService.cs
@@ -47,6 +47,9 @@ public class OpenVRService
                             if (OpenVR.Applications.IsApplicationInstalled("com.github.ellyvr.vrcvideocacher"))
                             {
                                 Logger.Information("Startup manifest registered successfully");
+
+                                Logger.Information("{AutoLaunchState} steamvr auto-launch", ConfigManager.Config.StartWithSteamVr ? "Enabling" : "Disabling");
+                                OpenVR.Applications.SetApplicationAutoLaunch("com.github.ellyvr.vrcvideocacher", ConfigManager.Config.StartWithSteamVr);
                             }
                             else
                             {

--- a/VRCVideoCacher/Utils/LaunchArgs.cs
+++ b/VRCVideoCacher/Utils/LaunchArgs.cs
@@ -7,12 +7,14 @@ public class LaunchArgs
     private const string DisableErrorReportingArg = "--disable-error-reporting";
     private const string GlobalPathArg = "--global-path";
     private const string OldPidArg = "--old-pid";
+    private const string KillExistingInstanceArg = "--kill-existing-instance";
 
     public static bool IsBypassArgumentPresent;
     public static bool HasGui = true;
     public static bool ErrorReporting = true;
     public static bool UseGlobalPath;
     public static int? OldPid;
+    public static bool KillExistingInstance = false;
 
     public static void SetupArguments(params string[] args)
     {
@@ -38,6 +40,9 @@ public class LaunchArgs
                 if (int.TryParse(pidStr, out var pid))
                     OldPid = pid;
             }
+
+            if (arg.Equals(KillExistingInstanceArg, StringComparison.OrdinalIgnoreCase))
+                KillExistingInstance = true;
         }
     }
 

--- a/VRCVideoCacher/ViewModels/SettingsViewModel.cs
+++ b/VRCVideoCacher/ViewModels/SettingsViewModel.cs
@@ -87,6 +87,9 @@ public partial class SettingsViewModel : ViewModelBase
     private string _statusMessage = string.Empty;
 
     [ObservableProperty]
+    private bool _startWithSteamVr;
+
+    [ObservableProperty]
     private bool _hasChanges;
 
     // Language selection
@@ -140,6 +143,7 @@ public partial class SettingsViewModel : ViewModelBase
         AutoUpdate = config.AutoUpdateVrcVideoCacher;
         CloseToTray = config.CloseToTray;
         StartMinimized = config.StartMinimized;
+        StartWithSteamVr = config.StartWithSteamVr;
         RedirectVRDancing = config.RedirectVRDancing;
         BlockedUrls.Clear();
         foreach (var url in config.BlockedUrls)
@@ -179,6 +183,7 @@ public partial class SettingsViewModel : ViewModelBase
     partial void OnAutoUpdateChanged(bool value) => SetHasChanges();
     partial void OnCloseToTrayChanged(bool value) => SetHasChanges();
     partial void OnStartMinimizedChanged(bool value) => SetHasChanges();
+    partial void OnStartWithSteamVrChanged(bool value) => SetHasChanges();
 
     [RelayCommand]
     private void SaveSettings()
@@ -208,6 +213,7 @@ public partial class SettingsViewModel : ViewModelBase
         config.AutoUpdateVrcVideoCacher = AutoUpdate;
         config.CloseToTray = CloseToTray;
         config.StartMinimized = StartMinimized;
+        config.StartWithSteamVr = StartMinimized;
         config.BlockedUrls = BlockedUrls.ToArray();
         config.BlockRedirect = BlockRedirect;
         config.RedirectVRDancing = RedirectVRDancing;

--- a/VRCVideoCacher/Views/SettingsView.axaml
+++ b/VRCVideoCacher/Views/SettingsView.axaml
@@ -55,6 +55,8 @@
                         <CheckBox IsChecked="{Binding CloseToTray}" Content="{loc:Tr CloseToTray}"/>
 
                         <CheckBox IsChecked="{Binding StartMinimized}" Content="{loc:Tr StartMinimized}"/>
+
+                        <CheckBox IsChecked="{Binding StartWithSteamVr}" Content="{loc:Tr StartWithSteamVr}"/>
                     </StackPanel>
                 </Border>
 

--- a/VRCVideoCacher/manifest.vrmanifest
+++ b/VRCVideoCacher/manifest.vrmanifest
@@ -2,8 +2,9 @@
     "source" : "builtin",
     "applications" : [{
         "app_key" : "com.github.ellyvr.vrcvideocacher",
-        "launch_type" : "url",
-        "url" : "steam://launch/4296960",
+        "launch_type" : "binary",
+        "binary_path_windows": "VRCVideoCacher.exe",
+        "binary_path_linux": "VRCVideoCacher",
         "is_dashboard_overlay" : true,
         "strings": {
             "en_us": {

--- a/VRCVideoCacher/manifest.vrmanifest
+++ b/VRCVideoCacher/manifest.vrmanifest
@@ -5,6 +5,7 @@
         "launch_type" : "binary",
         "binary_path_windows": "VRCVideoCacher.exe",
         "binary_path_linux": "VRCVideoCacher",
+        "arguments": "--kill-existing-instance",
         "is_dashboard_overlay" : true,
         "strings": {
             "en_us": {


### PR DESCRIPTION
- Figured out how not to have theater mode using the auto startup. Use binary launch, and need to move the manifest next to the exe.
- Add an option to enable start with SteamVR ourselves.
- If VRCVideoCacher starts up with `--kill-existing-instance`, it will kill any existing instances and start the new one.