### PR TITLE
Fix: keep OpenVR connection alive to receive VREvent_Quit from SteamVR

### DIFF
--- a/VRCVideoCacher/Services/OpenVRService.cs
+++ b/VRCVideoCacher/Services/OpenVRService.cs
@@ -1,4 +1,8 @@
 using System.Reflection;
+using System.Runtime.InteropServices;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
 using Serilog;
 using Valve.VR;
 
@@ -56,6 +60,7 @@ public class OpenVRService
                                 Logger.Warning("Failed to register startup manifest");
                             }
                         }
+                        await PollEventsUntilQuit();
                         break;
                     // Only retry if vrserver just isn't running yet
                     case EVRInitError.Init_HmdNotFound or EVRInitError.Init_HmdNotFoundPresenceFailed or EVRInitError.Init_NoServerForBackgroundApp:
@@ -77,6 +82,46 @@ public class OpenVRService
                     return;
                 }
             }
+        });
+    }
+
+    private static async Task PollEventsUntilQuit()
+    {
+        var vrEvent = new VREvent_t();
+        var eventSize = (uint)Marshal.SizeOf<VREvent_t>();
+
+        while (true)
+        {
+            await Task.Delay(500);
+
+            if (OpenVR.System == null)
+            {
+                Logger.Warning("OpenVR system became unavailable, assuming SteamVR closed");
+                break;
+            }
+
+            while (OpenVR.System.PollNextEvent(ref vrEvent, eventSize))
+            {
+                if ((EVREventType)vrEvent.eventType != EVREventType.VREvent_Quit)
+                    continue;
+
+                Logger.Information("SteamVR is shutting down, closing VRCVideoCacher");
+                OpenVR.System.AcknowledgeQuit_Exiting();
+
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
+                        lifetime.Shutdown();
+                });
+                return;
+            }
+        }
+
+        // SteamVR became unavailable without a clean VREvent_Quit (e.g. crash)
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
+                lifetime.Shutdown();
         });
     }
 }


### PR DESCRIPTION
## Problem

VRCVideoCacher does not close when SteamVR closes (closes #158).

## Root Cause

`OpenVRService.Start()` initialised OpenVR just long enough to register the app manifest, then immediately called `OpenVR.Shutdown()`. With the connection dropped, the app had no way to receive `VREvent_Quit` when SteamVR exits.

## Fix

Add `PollEventsUntilQuit()` - a lightweight async loop that keeps the OpenVR connection alive after manifest registration and polls for events every 500 ms.

- On `VREvent_Quit`: acknowledges the quit to SteamVR (`AcknowledgeQuit_Exiting`) then shuts down the Avalonia application lifetime on the UI thread.
- If `OpenVR.System` becomes `null` (vrserver crash): also shuts down the app so it does not linger as an orphan process.