### PR TITLE
Fix binary downloads failing due to HttpClient 100s timeout

### DIFF
--- a/VRCVideoCacher/YTDL/YtdlManager.cs
+++ b/VRCVideoCacher/YTDL/YtdlManager.cs
@@ -15,6 +15,11 @@ public class YtdlManager
     {
         DefaultRequestHeaders = { { "User-Agent", "VRCVideoCacher" } }
     };
+    private static readonly HttpClient DownloadHttpClient = new()
+    {
+        DefaultRequestHeaders = { { "User-Agent", "VRCVideoCacher" } },
+        Timeout = TimeSpan.FromMinutes(10)
+    };
     public static readonly string CookiesPath;
 
     public static readonly string YtdlPath =
@@ -211,7 +216,7 @@ public class YtdlManager
         Log.Information("Downloading Deno...");
         var url = assets.First().browser_download_url;
 
-        using var response = await HttpClient.GetAsync(url);
+        using var response = await DownloadHttpClient.GetAsync(url);
         if (!response.IsSuccessStatusCode)
         {
             Log.Information("Failed to download deno from github attempting fallback download.");
@@ -232,9 +237,9 @@ public class YtdlManager
                 await using var outputStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
                 await using var entryStream = await reader.OpenEntryStreamAsync();
                 await entryStream.CopyToAsync(outputStream);
-                FileTools.MarkFileExecutable(path);
                 Versions.CurrentVersion.Deno = json.tag_name;
                 Versions.Save();
+                FileTools.MarkFileExecutable(path);
                 Log.Information("Deno downloaded and extracted.");
                 return;
             }
@@ -258,7 +263,7 @@ public class YtdlManager
         }
         var latestVersion = (await response.Content.ReadAsStringAsync()).Trim();
         var url = $"{DenoFallBackDownloadURL}{latestVersion}/{assetName}";
-        using var downloadResponse = await HttpClient.GetAsync(url);
+        using var downloadResponse = await DownloadHttpClient.GetAsync(url);
         if (!downloadResponse.IsSuccessStatusCode)
         {
             Log.Error("Failed to download Deno from fallback URL: {ResponseStatusCode}", downloadResponse.StatusCode);
@@ -279,9 +284,9 @@ public class YtdlManager
                 await using var outputStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
                 await using var entryStream = await reader.OpenEntryStreamAsync();
                 await entryStream.CopyToAsync(outputStream);
-                FileTools.MarkFileExecutable(path);
                 Versions.CurrentVersion.Deno = latestVersion;
                 Versions.Save();
+                FileTools.MarkFileExecutable(path);
                 Log.Information("Deno downloaded and extracted.");
                 return;
             }
@@ -369,7 +374,7 @@ public class YtdlManager
         }
         Log.Information("Downloading FFmpeg...");
 
-        using var response = await HttpClient.GetAsync(url);
+        using var response = await DownloadHttpClient.GetAsync(url);
         await using var responseStream = await response.Content.ReadAsStreamAsync();
         var reader = await ReaderFactory.OpenAsyncReader(responseStream);
         var success = false;
@@ -441,7 +446,7 @@ public class YtdlManager
             if (assetVersion.name != assetName)
                 continue;
 
-            await using var stream = await HttpClient.GetStreamAsync(assetVersion.browser_download_url);
+            await using var stream = await DownloadHttpClient.GetStreamAsync(assetVersion.browser_download_url);
             if (string.IsNullOrEmpty(Program.UtilsPath))
                 throw new Exception("Failed to get YT-DLP path");
 


### PR DESCRIPTION
## Summary

- Add a dedicated `DownloadHttpClient` with a 10-minute timeout for file downloads (Deno, FFmpeg, yt-dlp). The default 100s `HttpClient` timeout is too short for large binaries (e.g. the Deno zip is ~115MB), causing a `TaskCanceledException` mid-download with no useful error shown to the user.
- Swap `Versions.Save()` to run before `FileTools.MarkFileExecutable()` so the downloaded version is recorded even if marking the file executable fails, preventing an infinite re-download loop on next restart.

## Test plan

- [ ] Trigger a Deno download on a slow connection and confirm it completes instead of timing out after 100s
- [ ] Confirm API calls (GitHub release checks) still use the default timeout
- [ ] On Linux without VRChat installed, confirm Deno version is saved to version.json even if `MarkFileExecutable` throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)