### PR TITLE
Quarantine in-flight video downloads to their own temporary subdirectory

### DIFF
--- a/VRCVideoCacher/Utils/TempDir.cs
+++ b/VRCVideoCacher/Utils/TempDir.cs
@@ -1,0 +1,38 @@
+namespace VRCVideoCacher.Utils;
+
+public class TempDir : IDisposable
+{
+    private const String Prefix = "VRCVideoCacher-";
+
+    private readonly DirectoryInfo _di = Directory.CreateTempSubdirectory(Prefix);
+    private bool _disposed;
+
+    ~TempDir()
+    {
+        Dispose(false);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    public string FullName => _di.FullName;
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        try
+        {
+            // Assume the temporary subdirectory still exists but is empty.
+            _di.Delete(false);
+        }
+        catch
+        {
+            // If we couldn't delete it (e.g. because it wasn't empty), then leave it around for debugging. The OS will
+            // eventually clean this up for us.
+        }
+        _disposed = true;
+    }
+}

--- a/VRCVideoCacher/YTDL/VideoDownloader.cs
+++ b/VRCVideoCacher/YTDL/VideoDownloader.cs
@@ -4,11 +4,14 @@ using System.Net;
 using System.Text;
 using Serilog;
 using VRCVideoCacher.Models;
+using VRCVideoCacher.Utils;
 
 namespace VRCVideoCacher.YTDL;
 
 public class VideoDownloader
 {
+    private const string TempDownloadMp4Name = "_tempVideo.mp4";
+    private const string TempDownloadWebmName = "_tempVideo.webm";
     private static readonly ILogger Log = Program.Logger.ForContext<VideoDownloader>();
     private static readonly HttpClient HttpClient = new()
     {
@@ -28,8 +31,8 @@ public class VideoDownloader
 
     static VideoDownloader()
     {
-        TempDownloadMp4Path = Path.Join(CacheManager.CachePath, "_tempVideo.mp4");
-        TempDownloadWebmPath = Path.Join(CacheManager.CachePath, "_tempVideo.webm");
+        TempDownloadMp4Path = Path.Join(CacheManager.CachePath, TempDownloadMp4Name);
+        TempDownloadWebmPath = Path.Join(CacheManager.CachePath, TempDownloadWebmName);
         Task.Run(DownloadThread);
     }
 
@@ -238,16 +241,8 @@ public class VideoDownloader
 
     private static async Task<bool> DownloadVRDancingVideoWithId(VideoInfo videoInfo)
     {
-        if (File.Exists(TempDownloadMp4Path))
-        {
-            Log.Warning("Temp file already exists, deleting...");
-            File.Delete(TempDownloadMp4Path);
-        }
-        if (File.Exists(TempDownloadWebmPath))
-        {
-            Log.Warning("Temp file already exists, deleting...");
-            File.Delete(TempDownloadWebmPath);
-        }
+        using var tempDir = new TempDir();
+        var tempDownloadMp4Path = Path.Join(tempDir.FullName, TempDownloadMp4Name);
 
         var url = videoInfo.VideoUrl;
         var process = new Process
@@ -263,7 +258,7 @@ public class VideoDownloader
                 StandardErrorEncoding = Encoding.UTF8,
             }
         };
-        process.StartInfo.Arguments = $"-q -o \"{TempDownloadMp4Path}\" --remux-video mp4 {url}";
+        process.StartInfo.Arguments = $"-q -o \"{tempDownloadMp4Path}\" --remux-video mp4 {url}";
         Log.Information("Downloading VRDancing Video: {Args}", process.StartInfo.Arguments);
         process.Start();
         await process.WaitForExitAsync();
@@ -283,10 +278,8 @@ public class VideoDownloader
             Log.Error("File already exists, canceling...");
             try
             {
-                if (File.Exists(TempDownloadMp4Path))
-                    File.Delete(TempDownloadMp4Path);
-                if (File.Exists(TempDownloadWebmPath))
-                    File.Delete(TempDownloadWebmPath);
+                if (File.Exists(tempDownloadMp4Path))
+                    File.Delete(tempDownloadMp4Path);
             }
             catch (Exception ex)
             {
@@ -295,13 +288,9 @@ public class VideoDownloader
 
             return false;
         }
-        if (File.Exists(TempDownloadMp4Path))
+        if (File.Exists(tempDownloadMp4Path))
         {
-            File.Move(TempDownloadMp4Path, filePath);
-        }
-        else if (File.Exists(TempDownloadWebmPath))
-        {
-            File.Move(TempDownloadWebmPath, filePath);
+            File.Move(tempDownloadMp4Path, filePath);
         }
         else
         {

--- a/VRCVideoCacher/YTDL/VideoDownloader.cs
+++ b/VRCVideoCacher/YTDL/VideoDownloader.cs
@@ -18,8 +18,6 @@ public class VideoDownloader
         DefaultRequestHeaders = { { "User-Agent", "VRCVideoCacher" } }
     };
     private static readonly ConcurrentQueue<VideoInfo> DownloadQueue = new();
-    private static readonly string TempDownloadMp4Path;
-    private static readonly string TempDownloadWebmPath;
 
     // Events for UI
     public static event Action<VideoInfo>? OnDownloadStarted;
@@ -31,8 +29,6 @@ public class VideoDownloader
 
     static VideoDownloader()
     {
-        TempDownloadMp4Path = Path.Join(CacheManager.CachePath, TempDownloadMp4Name);
-        TempDownloadWebmPath = Path.Join(CacheManager.CachePath, TempDownloadWebmName);
         Task.Run(DownloadThread);
     }
 
@@ -136,16 +132,9 @@ public class VideoDownloader
             return false;
         }
 
-        if (File.Exists(TempDownloadMp4Path))
-        {
-            Log.Warning("Temp file already exists, deleting...");
-            File.Delete(TempDownloadMp4Path);
-        }
-        if (File.Exists(TempDownloadWebmPath))
-        {
-            Log.Warning("Temp file already exists, deleting...");
-            File.Delete(TempDownloadWebmPath);
-        }
+        using var tempDir = new TempDir();
+        var tempDownloadMp4Path = Path.Join(tempDir.FullName, TempDownloadMp4Name);
+        var tempDownloadWebmPath = Path.Join(tempDir.FullName, TempDownloadWebmName);
 
         var args = new List<string>();
         args.Add("-q");
@@ -170,7 +159,7 @@ public class VideoDownloader
             var audioArg = string.IsNullOrEmpty(ConfigManager.Config.YtdlpDubLanguage)
                 ? "+ba[acodec=opus][ext=webm]"
                 : $"+(ba[acodec=opus][ext=webm][language={ConfigManager.Config.YtdlpDubLanguage}]/ba[acodec=opus][ext=webm])";
-            args.Add($"-o \"{TempDownloadWebmPath}\"");
+            args.Add($"-o \"{tempDownloadWebmPath}\"");
             args.Add($"-f \"bv*[height<={ConfigManager.Config.CacheYouTubeMaxResolution}][vcodec~='^av01'][ext=mp4][dynamic_range='SDR']{audioArg}/bv*[height<={ConfigManager.Config.CacheYouTubeMaxResolution}][vcodec~='vp9'][ext=webm][dynamic_range='SDR']{audioArg}\"");
         }
         else
@@ -179,7 +168,7 @@ public class VideoDownloader
             var audioArgPotato = string.IsNullOrEmpty(ConfigManager.Config.YtdlpDubLanguage)
                 ? "+ba[ext=m4a]"
                 : $"+(ba[ext=m4a][language={ConfigManager.Config.YtdlpDubLanguage}]/ba[ext=m4a])";
-            args.Add($"-o \"{TempDownloadMp4Path}\"");
+            args.Add($"-o \"{tempDownloadMp4Path}\"");
             args.Add($"-f \"bv*[height<=1080][vcodec~='^(avc|h264)']{audioArgPotato}/bv*[height<=1080][vcodec~='^av01'][dynamic_range='SDR']\"");
             args.Add("--remux-video mp4");
             // $@"-f best/bestvideo[height<=?720]+bestaudio {url} " %(id)s.%(ext)s
@@ -208,10 +197,10 @@ public class VideoDownloader
             Log.Error("File already exists, canceling...");
             try
             {
-                if (File.Exists(TempDownloadMp4Path))
-                    File.Delete(TempDownloadMp4Path);
-                if (File.Exists(TempDownloadWebmPath))
-                    File.Delete(TempDownloadWebmPath);
+                if (File.Exists(tempDownloadMp4Path))
+                    File.Delete(tempDownloadMp4Path);
+                if (File.Exists(tempDownloadWebmPath))
+                    File.Delete(tempDownloadWebmPath);
             }
             catch (Exception ex)
             {
@@ -220,13 +209,13 @@ public class VideoDownloader
             return false;
         }
 
-        if (File.Exists(TempDownloadMp4Path))
+        if (File.Exists(tempDownloadMp4Path))
         {
-            File.Move(TempDownloadMp4Path, filePath);
+            File.Move(tempDownloadMp4Path, filePath);
         }
-        else if (File.Exists(TempDownloadWebmPath))
+        else if (File.Exists(tempDownloadWebmPath))
         {
-            File.Move(TempDownloadWebmPath, filePath);
+            File.Move(tempDownloadWebmPath, filePath);
         }
         else
         {
@@ -305,16 +294,8 @@ public class VideoDownloader
 
     private static async Task<bool> DownloadVideoWithId(VideoInfo videoInfo)
     {
-        if (File.Exists(TempDownloadMp4Path))
-        {
-            Log.Warning("Temp file already exists, deleting...");
-            File.Delete(TempDownloadMp4Path);
-        }
-        if (File.Exists(TempDownloadWebmPath))
-        {
-            Log.Warning("Temp file already exists, deleting...");
-            File.Delete(TempDownloadWebmPath);
-        }
+        using var tempDir = new TempDir();
+        var tempDownloadMp4Path = Path.Join(tempDir.FullName, TempDownloadMp4Name);
 
         Log.Information("Downloading Video: {URL}", videoInfo.VideoUrl);
         var url = videoInfo.VideoUrl;
@@ -332,7 +313,7 @@ public class VideoDownloader
         }
 
         await using var stream = await response.Content.ReadAsStreamAsync();
-        await using var fileStream = new FileStream(TempDownloadMp4Path, FileMode.Create, FileAccess.Write, FileShare.None);
+        await using var fileStream = new FileStream(tempDownloadMp4Path, FileMode.Create, FileAccess.Write, FileShare.None);
         await stream.CopyToAsync(fileStream);
         fileStream.Close();
         response.Dispose();
@@ -340,13 +321,9 @@ public class VideoDownloader
 
         var fileName = $"{videoInfo.VideoId}.{videoInfo.DownloadFormat.ToString().ToLower()}";
         var filePath = Path.Join(CacheManager.CachePath, fileName);
-        if (File.Exists(TempDownloadMp4Path))
+        if (File.Exists(tempDownloadMp4Path))
         {
-            File.Move(TempDownloadMp4Path, filePath);
-        }
-        else if (File.Exists(TempDownloadWebmPath))
-        {
-            File.Move(TempDownloadWebmPath, filePath);
+            File.Move(tempDownloadMp4Path, filePath);
         }
         else
         {

--- a/VRCVideoCacher/YTDL/VideoDownloader.cs
+++ b/VRCVideoCacher/YTDL/VideoDownloader.cs
@@ -249,7 +249,6 @@ public class VideoDownloader
             File.Delete(TempDownloadWebmPath);
         }
 
-        Log.Information("Downloading Video: {URL}", videoInfo.VideoUrl);
         var url = videoInfo.VideoUrl;
         var process = new Process
         {
@@ -265,17 +264,14 @@ public class VideoDownloader
             }
         };
         process.StartInfo.Arguments = $"-q -o \"{TempDownloadMp4Path}\" --remux-video mp4 {url}";
-        Log.Information("Downloading VRDancing Video: {URL}", process.StartInfo.Arguments);
+        Log.Information("Downloading VRDancing Video: {Args}", process.StartInfo.Arguments);
         process.Start();
         await process.WaitForExitAsync();
         var error = await process.StandardError.ReadToEndAsync();
         error = error.Trim();
         if (process.ExitCode != 0)
         {
-            Log.Error("Failed to download YouTube Video: {exitCode} {URL} {error}", process.ExitCode, url, error);
-            if (error.Contains("Sign in to confirm you’re not a bot"))
-                Log.Error("Fix this error by following these instructions: https://github.com/clienthax/VRCVideoCacherBrowserExtension");
-
+            Log.Error("Failed to download VRDancing Video: {exitCode} {URL} {error}", process.ExitCode, url, error);
             return false;
         }
         Thread.Sleep(100);
@@ -309,11 +305,12 @@ public class VideoDownloader
         }
         else
         {
-            Log.Error("Failed to download YouTube Video: {URL}", url);
+            Log.Error("Failed to download VRDancing Video: {URL}", url);
             return false;
         }
 
         CacheManager.AddToCache(fileName);
+        Log.Information("VRDancing Video Downloaded: {URL}", $"{ConfigManager.Config.YtdlpWebServerUrl}/{fileName}");
         return true;
     }
 


### PR DESCRIPTION
### Motivation

This PR fixes #169, in which an interrupted video download can contaminate the next video download due to the presence of partial file(s) that yt-dlp creates but we don't explicitly check for.

Rather than trying to coerce yt-dlp to behave (e.g. with `--no-continue --no-part`) or expanding the file checks to a glob (i.e. `_tempVideo.*`), this PR quarantines each video download to their own temporary subdirectory, so handlers needn't worry about cleaning up before they start downloading.

### Testing

Log excerpts from some rudimentary testing follow.

#### Windows

<details><summary>Log excerpt for VRD video download</summary>

```
2026-06-30 20:15:55.891 +10:00 [INF] Downloading VRDancing Video: -q -o "C:\Users\puxlit\AppData\Local\Temp\VRCVideoCacher-xunnctwd.go1\_tempVideo.mp4" --remux-video mp4 https://eu2.vrdancing.club/4895/
2026-06-30 20:16:27.474 +10:00 [INF] VRDancing Video Downloaded: http://localhost:9696/MBntdULnZy1K6keAQJ9ZdCRkIHY2AeuVxOEbY6fE6I.mp4
```
</details>

<details><summary>Log excerpt for YT video download</summary>

```
2026-06-30 20:44:14.991 +10:00 [INF] Starting yt-dlp with args: -j --encoding utf-8 --ignore-config --no-playlist --no-warnings --no-mtime --no-progress --ffmpeg-location "C:\Users\puxlit\AppData\Roaming\VRCVideoCacher\Utils\ffmpeg.exe" --js-runtimes deno:"C:\Users\puxlit\AppData\Roaming\VRCVideoCacher\Utils\deno.exe" "https://www.youtube.com/watch?v=eyqUj3PGHv4"
2026-06-30 20:44:21.098 +10:00 [INF] Finished yt-dlp
2026-06-30 20:44:21.157 +10:00 [INF] Downloading YouTube Video: -q -o "C:\Users\puxlit\AppData\Local\Temp\VRCVideoCacher-eeeyk0ev.khz\_tempVideo.webm" -f "bv*[height<=1080][vcodec~='^av01'][ext=mp4][dynamic_range='SDR']+ba[acodec=opus][ext=webm]/bv*[height<=1080][vcodec~='vp9'][ext=webm][dynamic_range='SDR']+ba[acodec=opus][ext=webm]" --encoding utf-8 --ignore-config --no-playlist --no-warnings --no-mtime --no-progress --ffmpeg-location "C:\Users\puxlit\AppData\Roaming\VRCVideoCacher\Utils\ffmpeg.exe" --js-runtimes deno:"C:\Users\puxlit\AppData\Roaming\VRCVideoCacher\Utils\deno.exe" -- "eyqUj3PGHv4"
2026-06-30 20:44:30.035 +10:00 [INF] YouTube Video Downloaded: http://localhost:9696/eyqUj3PGHv4.webm
```
</details>

<details><summary>Log excerpt for PPD video download</summary>

Note: `DownloadVideoWithId` doesn't actually log the temp file path.

```
2026-06-30 20:57:26.175 +10:00 [INF] Downloading Video: http://cdn.pypy.dance/PnHXo76zN0U.mp4
2026-06-30 20:57:29.746 +10:00 [INF] Video Downloaded: http://localhost:9696/PnHXo76zN0U.mp4
```
</details>