### PR TITLE
Fix YouTube live URLs not being handled correctly

### DIFF
--- a/VRCVideoCacher/API/APIController.cs
+++ b/VRCVideoCacher/API/APIController.cs
@@ -184,6 +184,11 @@ public class ApiController : WebApiController
 
         Log.Information("Responding with URL: {URL}", response);
         await HttpContext.SendStringAsync(response, "text/plain", Encoding.UTF8);
+
+        // Don't attempt to cache if its a livestream
+        if (videoInfo.VideoId.Equals("live"))
+            return;
+
         // check if file is cached again to handle race condition
         (isCached, _, _) = GetCachedFile(videoInfo.VideoId, avPro);
         if (!isCached && (

--- a/VRCVideoCacher/YTDL/SiteHandlers/Sites/YouTubeHandler.cs
+++ b/VRCVideoCacher/YTDL/SiteHandlers/Sites/YouTubeHandler.cs
@@ -23,6 +23,8 @@ public class YouTubeHandler : ISiteHandler
             videoId = match.Groups[1].Value;
         else if (uri.AbsolutePath.StartsWith("/shorts/"))
             videoId = uri.AbsolutePath.Split('/')[^1];
+        else if (uri.AbsolutePath.TrimEnd("/").EndsWith("/live"))
+            videoId = "live";
 
         if (string.IsNullOrEmpty(videoId))
         {


### PR DESCRIPTION
This PR fixes an issue where YouTube live URLs, suck as `https://www.youtube.com/@LofiGirl/live`, could not be handled correctly.