### PR TITLE
Fix playback issues

### DIFF
--- a/VRCVideoCacher/YTDL/SiteHandlers/Sites/YouTubeHandler.cs
+++ b/VRCVideoCacher/YTDL/SiteHandlers/Sites/YouTubeHandler.cs
@@ -51,8 +51,7 @@ public class YouTubeHandler : ISiteHandler
         {
             // Using the Safari impersonation with the web client gets us the muxed m3u8's that aren't normally available otherwise.
             // These are the only streams that are compatible with AVPro currently due to WMF being unmaintained garbage.
-            args.Add("--impersonate=\"safari\"");
-            args.Add("--extractor-args=\"youtube:player_client=web\"");
+            args.Add("--extractor-args=\"youtube:player_client=web_safari,tv_downgraded\"");
 
             // AVPro
             var lang = ConfigManager.Config.YtdlpDubLanguage;

--- a/VRCVideoCacher/YTDL/VideoId.cs
+++ b/VRCVideoCacher/YTDL/VideoId.cs
@@ -125,8 +125,7 @@ public class VideoId
         args.Add("-i");
         args.Add("-J"); // --dump-single-json
         args.Add("-s");
-        args.Add("--impersonate=\"safari\"");
-        args.Add("--extractor-args=\"youtube:player_client=web\"");
+        args.Add("--extractor-args=\"youtube:player_client=web_safari,tv_downgraded\"");
 
 
         var (output, error, exitCode) = await RunYtdlpAsync(args, url);


### PR DESCRIPTION
This should hopefully fix recent issues with yt-dlp not working with cookies if the account is part of youtubes weird a/b testing

This also swaps the old Safari impersonation for yt-dlp's native web_safari client, it also adds tv_downgraded as an optional client to try after if safari fails, which should fix playback issues.

There is a number of other clients that will likely work, but tv_downgraded had the most success in my testing

**Videos that get pass through the fallback client may get limited to 360p**