### PR TITLE
Add Support NicoNico Short

### DIFF
--- a/VRCVideoCacher/YTDL/SiteHandlers/Sites/NicoVideoHandler.cs
+++ b/VRCVideoCacher/YTDL/SiteHandlers/Sites/NicoVideoHandler.cs
@@ -10,11 +10,11 @@ public class NicoVideoHandler : ISiteHandler
     private static readonly ILogger Log = Program.Logger.ForContext<NicoVideoHandler>();
 
     // Matches full nicovideo/niconico URLs
-    private static readonly Regex NicoID1 = new(@"^(https?)://(live|www)\.nicovideo\.jp/watch/(.+)$", RegexOptions.Compiled);
+    private static readonly Regex NicoID1 = new(@"^(https?)://(live|www)\.nicovideo\.jp/(watch|shorts)/(.+)$", RegexOptions.Compiled);
     private static readonly Regex NicoID2 = new(@"^(https?)://nico\.ms/(.+)$", RegexOptions.Compiled);
 
     // Matches bare Nico video/live IDs
-    private static readonly Regex NicoID4 = new(@"^(sm\d+|nm\d+|am\d+|fz\d+|ut\d+|dm\d+|so\d+|ax\d+|ca\d+|cd\d+|cw\d+|fx\d+|ig\d+|na\d+|om\d+|sd\d+|sk\d+|yk\d+|yo\d+|za\d+|zb\d+|zc\d+|zd\d+|ze\d+|nl\d+|ch\d+|\d+|lv\d+)$", RegexOptions.Compiled);
+    private static readonly Regex NicoID4 = new(@"^(sm\d+|nm\d+|am\d+|fz\d+|ut\d+|dm\d+|so\d+|ax\d+|ca\d+|cd\d+|cw\d+|fx\d+|ig\d+|na\d+|om\d+|sd\d+|sk\d+|yk\d+|yo\d+|za\d+|zb\d+|zc\d+|zd\d+|ze\d+|nl\d+|ch\d+|\d+|lv\d+|ss\d+)$", RegexOptions.Compiled);
 
     public bool CanHandle(Uri uri) => false; // rewrite only, GenericHandler picks up after
 
@@ -27,7 +27,7 @@ public class NicoVideoHandler : ISiteHandler
 
         var (m, group) = new[]
         {
-            (NicoID1.Match(url), 3),
+            (NicoID1.Match(url), 4),
             (NicoID2.Match(url), 2),
             (NicoID4.Match(url), 1),
         }.FirstOrDefault(x => x.Item1.Success);


### PR DESCRIPTION
Niconico Video implemented short-form videos starting from April 15, 2026. Therefore, I am submitting a pull request to add support for short video URLs and IDs.
https://blog.nicovideo.jp/niconews/270458.html

Here is the video used for testing.
https://www.nicovideo.jp/watch/ss46699746
https://www.nicovideo.jp/shorts/ss46699746