### PR TITLE
Fix Steam path for Flatpak was not detected correctly.

### DIFF
--- a/VRCVideoCacher/FileTools.cs
+++ b/VRCVideoCacher/FileTools.cs
@@ -13,7 +13,7 @@ public class FileTools
     private static readonly string? BackupPathVrc;
     private static readonly string? YtdlPathReso;
     private static readonly string? BackupPathReso;
-    private static readonly ImmutableList<string> SteamPaths = [".var/app/com.valvesoftware.Steam", ".steam/steam", ".local/share/Steam"];
+    private static readonly ImmutableList<string> SteamPaths = [".var/app/com.valvesoftware.Steam/data/Steam", ".steam/steam", ".local/share/Steam"];
 
     static FileTools()
     {


### PR DESCRIPTION
This PR fixes an issue where Steam versions of Flatpak cannot be detected due to the following error:

````
[16:13:55 ERR FileTools] No Steam folder exists!
[16:13:55 ERR <none>] Backend error
System.TypeInitializationException: The type initializer for 'VRCVideoCacher.FileTools' threw an exception.
---> System.Exception: Unable to find VRChat compat data
at VRCVideoCacher.FileTools..cctor()
--- End of inner exception stack trace ---
at VRCVideoCacher.FileTools.BackupAllYtdl()
at VRCVideoCacher.Program.InitVrcVideoCacher()
at VRCVideoCacher.Program.<>c.<<InitializeUIBackend>b__15_0>d.MoveNext()
````

This was caused by an incorrect definition of `SteamPaths` in `VRCVideoCacher/FileTools.cs`. This PR corrects the `SteamPaths` value to be set correctly.

````
[16:47:39 DBG FileTools] Checking Steam libraryfolders.vdf at /home/nexryai/.var/app/com.valvesoftware.Steam/data/Steam/steamapps/libraryfolders.vdf
[16:47:41 DBG YtdlManager] Extracting file deno (95600728 bytes)
[16:47:41 INF YtdlManager] Deno downloaded and extracted.
[16:47:41 INF WebServer] Running HTTPListener: Unosquare HTTP Listener
````

For details, please refer to the comments in the following issue.
related: https://github.com/EllyVR/VRCVideoCacher/issues/163#issuecomment-5475284025