### PR TITLE
Fix TaskCanceledException when downloading large files

### DIFF
--- a/VRCVideoCacher/Program.cs
+++ b/VRCVideoCacher/Program.cs
@@ -133,13 +133,17 @@ internal sealed class Program
         // Start backend on background thread
         Task.Run(async () =>
         {
-            try
+            for (var i = 0; i < 3; i++)
             {
-                await InitVrcVideoCacher();
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Backend error: {Message}", ex.Message);
+                try
+                {
+                    await InitVrcVideoCacher();
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "Backend error: {Message}", ex.Message);
+                }
             }
         });
     }

--- a/VRCVideoCacher/YTDL/YtdlManager.cs
+++ b/VRCVideoCacher/YTDL/YtdlManager.cs
@@ -217,37 +217,47 @@ public class YtdlManager
         Log.Information("Downloading Deno...");
         var url = assets.First().browser_download_url;
 
-        using var response = await HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
-        if (!response.IsSuccessStatusCode)
+        try
         {
+            using var response = await HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+            if (!response.IsSuccessStatusCode)
+            {
+                Log.Information("Failed to download deno from github attempting fallback download.");
+                await TryDownloadDenoFallback(assetName);
+                return;
+            }
+            await using var responseStream = await response.Content.ReadAsStreamAsync();
+            var reader = await ReaderFactory.OpenAsyncReader(responseStream);
+            try
+            {
+                while (await reader.MoveToNextEntryAsync())
+                {
+                    if (reader.Entry.Key == null || reader.Entry.IsDirectory)
+                        continue;
+
+                    Log.Debug("Extracting file {Name} ({Size} bytes)", reader.Entry.Key, reader.Entry.Size);
+                    var path = Path.Join(Program.UtilsPath, reader.Entry.Key);
+                    await using var outputStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+                    await using var entryStream = await reader.OpenEntryStreamAsync();
+                    await entryStream.CopyToAsync(outputStream);
+                    FileTools.MarkFileExecutable(path);
+                    Versions.CurrentVersion.Deno = json.tag_name;
+                    Versions.Save();
+                    Log.Information("Deno downloaded and extracted.");
+                    return;
+                }
+            }
+            finally
+            {
+                await reader.DisposeAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Backend error: {Message}", ex.Message);
             Log.Information("Failed to download deno from github attempting fallback download.");
             await TryDownloadDenoFallback(assetName);
             return;
-        }
-        await using var responseStream = await response.Content.ReadAsStreamAsync();
-        var reader = await ReaderFactory.OpenAsyncReader(responseStream);
-        try
-        {
-            while (await reader.MoveToNextEntryAsync())
-            {
-                if (reader.Entry.Key == null || reader.Entry.IsDirectory)
-                    continue;
-
-                Log.Debug("Extracting file {Name} ({Size} bytes)", reader.Entry.Key, reader.Entry.Size);
-                var path = Path.Join(Program.UtilsPath, reader.Entry.Key);
-                await using var outputStream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
-                await using var entryStream = await reader.OpenEntryStreamAsync();
-                await entryStream.CopyToAsync(outputStream);
-                FileTools.MarkFileExecutable(path);
-                Versions.CurrentVersion.Deno = json.tag_name;
-                Versions.Save();
-                Log.Information("Deno downloaded and extracted.");
-                return;
-            }
-        }
-        finally
-        {
-            await reader.DisposeAsync();
         }
 
         Log.Error("Failed to extract Deno files.");

--- a/VRCVideoCacher/YTDL/YtdlManager.cs
+++ b/VRCVideoCacher/YTDL/YtdlManager.cs
@@ -217,7 +217,7 @@ public class YtdlManager
         Log.Information("Downloading Deno...");
         var url = assets.First().browser_download_url;
 
-        using var response = await HttpClient.GetAsync(url);
+        using var response = await HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
         if (!response.IsSuccessStatusCode)
         {
             Log.Information("Failed to download deno from github attempting fallback download.");
@@ -264,7 +264,7 @@ public class YtdlManager
         }
         var latestVersion = (await response.Content.ReadAsStringAsync()).Trim();
         var url = $"{DenoFallBackDownloadURL}{latestVersion}/{assetName}";
-        using var downloadResponse = await HttpClient.GetAsync(url);
+        using var downloadResponse = await HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
         if (!downloadResponse.IsSuccessStatusCode)
         {
             Log.Error("Failed to download Deno from fallback URL: {ResponseStatusCode}", downloadResponse.StatusCode);
@@ -377,7 +377,7 @@ public class YtdlManager
         }
         Log.Information("Downloading FFmpeg...");
 
-        using var response = await HttpClient.GetAsync(url);
+        using var response = await HttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
         await using var responseStream = await response.Content.ReadAsStreamAsync();
         var reader = await ReaderFactory.OpenAsyncReader(responseStream);
         var success = false;


### PR DESCRIPTION
When downloading the Deno executable, `HttpClient`'s default behavior has a timeout limit of 100 seconds. Since the Deno executable is more than 92 MB, it may take longer than 100 seconds to download.

Most of the time, the download completes normally when the network is fast. However, GitHub or the network may occasionally be slow. With the default behavior, `HttpClient` only has 100 seconds to download the entire file before the task is canceled.

This PR makes three changes:

1. Use `HttpCompletionOption.ResponseHeadersRead` when downloading large files such as Deno.
2. Fall back to the alternative Deno download source if an exception occurs while downloading Deno.
3. Retry up to 3 times if `InitVrcVideoCacher` throws an exception.
