### PR TITLE
Fix Log Viewer not scrolling to the bottom when switching pages

### DIFF
--- a/VRCVideoCacher/Views/LogViewerView.axaml.cs
+++ b/VRCVideoCacher/Views/LogViewerView.axaml.cs
@@ -1,12 +1,15 @@
 using System.Collections.Specialized;
-using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
 using VRCVideoCacher.ViewModels;
 
 namespace VRCVideoCacher.Views;
 
 public partial class LogViewerView : UserControl
 {
+    private ScrollViewer? _scrollViewer;
+
     public LogViewerView()
     {
         InitializeComponent();
@@ -20,31 +23,29 @@ public partial class LogViewerView : UserControl
             }
         };
 
-        // Scroll to bottom when view becomes visible
-        PropertyChanged += OnPropertyChanged;
-    }
-
-    private void OnPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
-    {
-        if (e.Property == IsVisibleProperty && e.NewValue is true)
+        Loaded += (_, _) =>
         {
-            ScrollToBottom();
-        }
+            _scrollViewer ??= LogListBox.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+
+            if (DataContext is LogViewerViewModel { AutoScroll: true })
+                ScrollToBottomDeferred();
+        };
     }
 
     private void OnLogEntriesChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         if (DataContext is LogViewerViewModel { AutoScroll: true } && e.Action == NotifyCollectionChangedAction.Add)
         {
-            ScrollToBottom();
+            ScrollToBottomDeferred();
         }
     }
 
+    private void ScrollToBottomDeferred() => Dispatcher.UIThread.Post(ScrollToBottom, DispatcherPriority.Render);
+
     private void ScrollToBottom()
     {
-        if (LogListBox.ItemCount > 0)
-        {
-            LogListBox.ScrollIntoView(LogListBox.ItemCount - 1);
-        }
+        if (_scrollViewer == null) return;
+        var maxOffset = Math.Max(0, _scrollViewer.Extent.Height - _scrollViewer.Viewport.Height);
+        _scrollViewer.Offset = new(_scrollViewer.Offset.X, maxOffset);
     }
 }


### PR DESCRIPTION
This PR fixes an issue where the Log Viewer does not scroll to the bottom after switching pages.