### PR TITLE
Support fallback to english when translation is missing

### DIFF
--- a/VRCVideoCacher/Languages/EmbeddedJsonLocalizer.cs
+++ b/VRCVideoCacher/Languages/EmbeddedJsonLocalizer.cs
@@ -8,6 +8,10 @@ namespace VRCVideoCacher.Languages;
 public class EmbeddedJsonLocalizer : BaseLocalizer
 {
     private FrozenDictionary<string, string> _languageStrings = new Dictionary<string, string>().ToFrozenDictionary();
+#if !DEBUG
+    private FrozenDictionary<string, string> _enLanguageStrings = new Dictionary<string, string>().ToFrozenDictionary();
+    private bool _enLanguageLoaded;
+#endif
 
     private const string prefix = "VRCVideoCacher.Languages.";
     private const string suffix = ".loc.json";
@@ -37,11 +41,34 @@ public class EmbeddedJsonLocalizer : BaseLocalizer
         UpdateDisplayLanguages();
     }
 
+#if !DEBUG
+    private void EnglishLanguageLoad(Assembly assembly)
+    {
+        if (_enLanguageLoaded) return;
+        var resourceName = assembly.GetManifestResourceNames()
+            .First(r => r.Equals($"{prefix}{FallbackLanguage}{suffix}"));
+
+        using var stream = assembly.GetManifestResourceStream(resourceName)!;
+        using var reader = new StreamReader(stream);
+        var json = JObject.Parse(reader.ReadToEnd());
+
+        _enLanguageStrings = json.Properties()
+            .ToDictionary(k => k.Name, v => v.Value?.ToString() ?? v.Name)
+            .ToFrozenDictionary();
+
+        _enLanguageLoaded = true;
+    }
+#endif
+
     protected override void OnLanguageChanged()
     {
         var assembly = Assembly.GetExecutingAssembly();
         var resourceName = assembly.GetManifestResourceNames()
             .First(r => r.Equals($"{prefix}{_language}{suffix}"));
+
+#if !DEBUG
+        EnglishLanguageLoad(assembly);
+#endif
 
         using var stream = assembly.GetManifestResourceStream(resourceName)!;
         using var reader = new StreamReader(stream);
@@ -63,6 +90,13 @@ public class EmbeddedJsonLocalizer : BaseLocalizer
         {
             return value;
         }
+
+#if !DEBUG
+        if (_enLanguageStrings?.TryGetValue(key, out var enValue) == true)
+        {
+            return enValue;
+        }
+#endif
 
         return base.Language + ":" + key;
     }


### PR DESCRIPTION
This PR adds support for automatically falling back to English when translations are missing.
In debug environments, the fallback is disabled so missing translations can still be detected and debugged.