### PR TITLE
Stop showing full log messages in the status bar

### DIFF
--- a/VRCVideoCacher/Services/StatusService.cs
+++ b/VRCVideoCacher/Services/StatusService.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+using Swan;
 using VRCVideoCacher.Models;
 
 namespace VRCVideoCacher.Services;
@@ -89,7 +91,7 @@ public sealed record StatusSnapshot(
 /// warning/error briefly by piggy-backing on <see cref="LogService.OnLogEntry"/>.
 /// Thread-safe; the UI marshals <see cref="Changed"/> onto the UI thread itself.
 /// </summary>
-public static class StatusService
+public static partial class StatusService
 {
     private static readonly ConcurrentDictionary<Guid, StatusActivity> Activities = new();
     private static long _seq;
@@ -194,6 +196,9 @@ public static class StatusService
     {
         // entry.Level is the short code emitted by LogService ("WRN", "ERR", "FTL").
         if (entry.Level is "WRN" or "ERR" or "FTL")
-            Flash(entry.Message, StatusLevel.Warning);
+            Flash(NewLineRegex().Replace(entry.Message, "").Truncate(200, "...") ?? "", StatusLevel.Warning);
     }
+
+    [GeneratedRegex(@"\r\n|\r|\n")]
+    private static partial Regex NewLineRegex();
 }


### PR DESCRIPTION
This PR fixes an issue where the status bar shows the full log message by limiting its length to 200 characters.
